### PR TITLE
Manage yat sessions as a service

### DIFF
--- a/init/yat@.service
+++ b/init/yat@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Create yat.sh session on startup
+After=ssh-agent.service
+
+[Service]
+Type=forking
+Environment="SSH_AUTH_SOCK=%t/keyring/ssh"
+Environment="EMACS_DAEMON=%i"
+Environment="TERM=xterm-256color"
+ExecStart=/home/krahser/.bin/yat.sh %i
+ExecStop=/home/krahser/.bin/yat.sh close %i
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
I've found emamux, this allows to interact emacs with tmux. Since I'm running emacs-daemons and I want to have them ready when my user is login. I've created a yat@.service for systemd. 
This service will create a session in the background. Emamux,  requires that emacs daemon is creating inside tmux to work. 
So, for example, I will start the session local.
```systemctl --user start yat@local```
And the session will start emacs daemon. If you look at the yat@.service, you will find that I add a EMACS_DAEMON with the same name of the yat session. So After it finish it will connect with emacsclient.
Here a dirty example of how I create the sessions:
```
new_session -d -n 'Emacs'
send_line 'Emacs' 'if [ -x "$(command -v ps aux | grep emacs | grep ${EMACS_DAEMON})"]; then /usr/bin/emacs --daemon=${EMACS_DAEMON}; fi'
send_line 'Emacs' 'emacsclient -s /tmp/krahser/emacs1000/${EMACS_DAEMON} -t'
```