### PR TITLE
Refactor session creation to allow deattached sessions

### DIFF
--- a/lib/global_helpers.sh
+++ b/lib/global_helpers.sh
@@ -99,4 +99,26 @@ function _unset_opt()
     shopt -u $*
 }
 
+function _create_session()
+{
+    if ! tmux has-session -t $SESSION 2> /dev/null ; then
+
+        session_file="$(_find_session_file $SESSION)"
+        if [ -z "$session_file" ]; then
+            tmux new-session -d -s $SESSION
+        else
+            if [ -h $session_file ]; then
+                session_name=$(_extract 'SESSION' $session_file | tr -d ' ')
+                [ ! -z $session_name ] && SESSION=${session_name}
+            fi
+            custom_loader=$(_extract 'LOADER' $session_file | tr -d ' ')
+            if [ ! -z $custom_loader ] && _is_command $custom_loader; then
+                exec yatsh-$custom_loader $session_file
+            else
+                source $session_file
+            fi
+        fi
+    fi
+}
+
 # TODO: add function to check for tmux executable

--- a/libexec/yatsh-create
+++ b/libexec/yatsh-create
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 usage(){
-    echo -e "Start/Attach tmux session."
+    echo -e "Create deattached tmux session."
     echo -e "Usage: ${SCPT_NAME} SESSION"
 }
 
@@ -16,13 +16,3 @@ TMUX_OLD=$TMUX
 TMUX=
 
 _create_session
-
-if [ -z "$DAEMON" ]; then
-   if [ "$TMUX_OLD" = "" ]; then
-       tmux attach-session -t $SESSION
-   else
-       tmux switch-client -t $SESSION
-   fi
-fi
-
-TMUX=$TMUX_OLD


### PR DESCRIPTION
I've found that using [ob-tmux](https://github.com/ahendriksen/ob-tmux) it is possible to send code blocks to sessions.
Considering that each project, might have local environment variables that are required to be loaded in order to exec the source block successfully. I'm using direnv, along with emacs .dir-locals.el settings.
While direnv will load all the variables, when emacs recognize the .dir-locals.el file it's executed, in my case to create my yat session.

.dir-locals.el
`((nil . (( eval . (yat-session "example")))))`

where yat-session is the following definition in elisp:
```
(defun yat-session (session)
  "Create yat session"
  (async-shell-command (concat "ys create " session))
  )
```

With those settings, I can send and execute the following code block, on an specific sessionName and Window, with the keystrokes Ctrl-c + Ctrl-c

```
  #+begin_src tmux :session sessionName:WindowName
    kubectl -A pods
  #+end_src
```